### PR TITLE
Fix issue #20

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,15 @@ We don't recommend working with raw YUV files, as they do not carry the metadata
 To convert YUV into Y4M, use the basic command:
 
 ```bash
-ffmpeg -f rawvideo -pix_fmt yuv420p -framerate 24 -video_size 1920x1080 -i input.yuv -c:v copy output.y4m
+ffmpeg -f rawvideo -pix_fmt yuv420p -framerate 24 -video_size 1920x1080 -i input.yuv -f yuv4mpegpipe output.y4m
 ```
 
 Adapt the parameters to your input file (i.e., the pixel format, framerate, and resolution).
+
+NOTE: If you are working with 10-bit content (e.g., if your input pixel format is `yuv420p10le`), you must add the `-strict -1` flag to the command above:
+```bash
+ffmpeg -f rawvideo -pix_fmt yuv420p -framerate 24 -video_size 1920x1080 -i input.yuv -f yuv4mpegpipe -strict -1 output.y4m
+```
 
 If you just want to convert an existing (e.g. MP4) file into Y4M, use:
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Adapt the parameters to your input file (i.e., the pixel format, framerate, and 
 
 NOTE: If you are working with 10-bit content (e.g., if your input pixel format is `yuv420p10le`), you must add the `-strict -1` flag to the command above:
 ```bash
-ffmpeg -f rawvideo -pix_fmt yuv420p -framerate 24 -video_size 1920x1080 -i input.yuv -f yuv4mpegpipe -strict -1 output.y4m
+ffmpeg -f rawvideo -pix_fmt yuv420p10le -framerate 24 -video_size 1920x1080 -i input.yuv -f yuv4mpegpipe -strict -1 output.y4m
 ```
 
 If you just want to convert an existing (e.g. MP4) file into Y4M, use:


### PR DESCRIPTION
I think the changes to the README.md file are self-explanatory. The only thing I am unsure of is whether the `-strict -1` flag necessary for 10-bit content shall be mentioned in the "Usage with YUV or Y4M files" section (as is the case now) or should it rather be mentioned in the "Usage for > 8-bit Content".

Fixes issue #20.